### PR TITLE
chore(docs): pass code prop to Pre component

### DIFF
--- a/docs/src/components/code-block.tsx
+++ b/docs/src/components/code-block.tsx
@@ -33,6 +33,7 @@ export function CodeBlock({
         </div>
       )}
       <Pre
+        code={code}
         data-language={language}
         className={cn("px-4", title ? "rounded-t-none" : "")}
         {...props}


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md)
      (updated 2025-03-17).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

Pass code prop to Pre component to allow coping from CodeBlock

---

💯
