### PR TITLE
feat(docs): a bunch of docs updates

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -76,7 +76,7 @@ bun create tnt-stack@latest
 ```
 
 For more information, visit the
-[docs](https://create.tntstack.org/docs/installation).
+[docs](https://create.tntstack.org/docs/getting-started).
 
 <h2 id="features">🛠 Features</h2>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,160 @@
-# README
+# Create TNT Stack Documentation Site
 
-Welcome to the documentation for the Create TNT Stack (CTS) project.
+Welcome to the official documentation site for **Create TNT Stack**! This site
+is built with **Next.js** and **MDX** to provide a seamless experience for
+learning how to use the TNT-Powered stack to build modern web applications.
 
-This repository contains all the necessary information and guides to help you
-understand and work with CTS.
+## Outline
 
-For more details, explore the available documentation files.
+- [Features](#features)
+- [Run Site Locally](#run-site-locally)
+- [Command Cheat Sheet](#command-cheat-sheet)
+- [Customize This Site](#customize-this-site)
+  - [Sidebar Navigation](#sidebar-navigation)
+  - [CSS Styling](#css-styling)
+  - [Code Block Customization](#code-block-customization)
+
+## Features
+
+- ✅ **MDX support** for combining Markdown and React components
+- ✅ **Responsive design** with Tailwind CSS
+- ✅ **Sidebar navigation** for easy exploration
+- ✅ **Dark mode** with shadcn-style theming
+- ✅ **Customizable code blocks** with syntax highlighting
+- ✅ **Built with Next.js** for fast and scalable performance
+
+## Run Site Locally
+
+To run the documentation site locally, follow these steps:
+
+```bash
+git clone https://github.com/SlickYeet/create-tnt-stack.git
+cd create-tnt-stack/docs
+bun install
+bun dev
+```
+
+This will start the development server at `http://localhost:3000`.
+
+## Command Cheat Sheet
+
+All commands are run from the `docs` directory of the project.
+
+| Command       | Action                                            |
+| ------------- | ------------------------------------------------- |
+| `bun install` | Installs dependencies                             |
+| `bun dev`     | Starts the development server at `localhost:3000` |
+| `bun build`   | Builds the production site to `.next/`            |
+| `bun lint`    | Lints the code                                    |
+| `bun format`  | Formats the code                                  |
+
+## Customize This Site
+
+### Sidebar Navigation
+
+The sidebar navigation is defined in `src/constants/index.ts` under the
+`SIDEBAR_NAVIGATION` constant. You can customize the structure by modifying this
+object. Here’s an example of the current structure:
+
+```ts title="SIDEBAR_NAVIGATION"
+export const SIDEBAR_NAVIGATION = [
+  // Create TNT Stack
+  {
+    title: "Create TNT Stack",
+    slug: "create-tnt-stack",
+    items: [
+      { slug: "introduction", title: "Introduction" },
+      { slug: "getting-started", title: "Getting Started" },
+      { slug: "why", title: "Why?" },
+    ],
+  },
+  // Usage
+  {
+    title: "Usage",
+    slug: "usage",
+    items: [
+      { slug: "first-steps", title: "First Steps" },
+      { slug: "nextjs", title: "Next.js" },
+      { slug: "payloadcms", title: "Payload CMS" },
+    ],
+  },
+  // Deployment
+  {
+    title: "Deployment",
+    slug: "deployment",
+    items: [
+      { slug: "vercel", title: "Vercel" },
+      { slug: "netlify", title: "Netlify" },
+    ],
+  },
+  // Roadmap
+  {
+    title: "Roadmap",
+    slug: "roadmap",
+    items: [{ slug: "v1", title: "Version 1" }],
+  },
+] as const
+```
+
+To add or remove sections, simply update this array.
+
+### CSS Styling
+
+The bulk of the CSS styling is handled via **Tailwind CSS**. Global styles and
+theming are defined in `globals.css`. For example, you can customize the color
+scheme or typography by modifying the Tailwind configuration.
+
+### Code Block Customization
+
+Code blocks in the documentation are composed of three main components:
+
+1. `figcaption`: Displays the title of the code block.
+2. `pre`: Handles the primary block styles.
+3. `code`: Used for inline code blocks or when no language is provided.
+
+Some data-driven styles for these components are defined in `globals.css`. For
+example:
+
+```css title="globals.css"
+/* Code Extras */
+@layer utilities {
+  .mdx pre [data-line] {
+    @apply px-5;
+  }
+  .mdx figure:has(figcaption) pre {
+    @apply rounded-t-none;
+  }
+  .mdx span .highlighted-word {
+    @apply bg-muted-foreground/20 text-foreground -mx-1 rounded-sm px-1 py-0.5;
+  }
+  .mdx span.diff.remove::before {
+    content: "-";
+    @apply absolute left-1.5 text-red-500;
+  }
+  .mdx span.diff.remove {
+    @apply !bg-red-500/10;
+  }
+  .mdx span.diff.add::before {
+    content: "+";
+    @apply absolute left-1.5 text-emerald-500;
+  }
+  .mdx span.diff.add {
+    @apply !bg-emerald-500/10;
+  }
+  .mdx span.highlighted {
+    @apply !bg-muted-foreground/10;
+  }
+}
+```
+
+## Contribution Guidelines
+
+We 💖 contributors! If you’d like to contribute to the documentation, please
+refer to the
+[Contribution Guidelines](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md).
+It includes detailed instructions on setting up your environment, making
+changes, and submitting pull requests.
+
+Thank you for visiting the Create TNT Stack documentation site! If you have any
+questions or feedback, feel free to open an issue or join the discussion on
+[GitHub](https://github.com/SlickYeet/create-tnt-stack).

--- a/docs/src/app/docs/(create-tnt-stack)/getting-started/page.mdx
+++ b/docs/src/app/docs/(create-tnt-stack)/getting-started/page.mdx
@@ -30,8 +30,8 @@ bun create tnt-stack@latest
 ```
 
 It is as simple as that. Once you have answered all the prompts, you can
-checkout the [First Steps](/docs/usage/first-steps) section to learn more about
-how to use the TNT Stack.
+checkout the [First Steps](/docs/first-steps) section to learn more about how to
+use the TNT Stack.
 
 ## Advanced Installation
 

--- a/docs/src/app/docs/layout.tsx
+++ b/docs/src/app/docs/layout.tsx
@@ -18,7 +18,7 @@ export default function DocsLayout({
       className="container py-5 lg:py-10"
     >
       <div className="grid grid-cols-1 gap-8 md:grid-cols-12 lg:grid-cols-15">
-        <div className="sm:col-span-3">
+        <div className="hidden sm:col-span-3 md:block">
           <DocsSidebar />
         </div>
         <div id="mdx" className="mdx col-span-1 md:col-span-9">

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -277,7 +277,7 @@
 /* GFM Table */
 @layer utilities {
   .mdx table {
-    @apply w-full table-auto;
+    @apply my-6 w-full table-auto;
   }
   .mdx th {
     @apply px-4 text-left font-bold;

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -86,7 +86,7 @@
   --popover: 240 10% 3.9%;
   --popover-foreground: 0 0% 98%;
 
-  --primary: 255 60% 56%;
+  --primary: 255 60% 66%;
   --primary-foreground: 0 0% 98%;
 
   --secondary: 240 5% 64.9%;

--- a/docs/src/components/code-block.tsx
+++ b/docs/src/components/code-block.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 
 import { Pre, PreProps } from "@/components/mdx/pre"
 import { cn, processCode } from "@/lib/utils"
+import { Figcaption } from "@/mdx-components"
 
 interface CodeBlockProps extends PreProps {
   code: string
@@ -27,11 +28,7 @@ export function CodeBlock({
 
   return (
     <div className={cn("mdx", className)}>
-      {title && (
-        <div className="bg-muted/80 border-muted -mb-6 min-w-sm rounded-t-lg border px-5 py-2">
-          {title}
-        </div>
-      )}
+      {title && <Figcaption>{title}</Figcaption>}
       <Pre
         code={code}
         data-language={language}

--- a/docs/src/components/docs/sidebar.tsx
+++ b/docs/src/components/docs/sidebar.tsx
@@ -1,23 +1,21 @@
 "use client"
 
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
 import { motion } from "motion/react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { SIDEBAR_NAVIGATION } from "@/constants"
 import { cn } from "@/lib/utils"
 import { H3 } from "@/mdx-components"
 
-export function DocsSidebar() {
-  const pathname = usePathname()
-  const [isOpen, setIsOpen] = useState<boolean>(false)
+interface DocsSidebarProps {
+  isOpen?: boolean
+}
 
-  const toggleMobileMenu = () => {
-    setIsOpen(!isOpen)
-  }
+export function DocsSidebar({ isOpen }: DocsSidebarProps) {
+  const pathname = usePathname()
 
   useEffect(() => {
     if (isOpen) {
@@ -33,10 +31,10 @@ export function DocsSidebar() {
   }, [isOpen])
 
   return (
-    <>
-      <div className="sticky top-20 hidden md:block">
-        <ScrollArea className="h-[calc(100vh-7rem)]">
-          <aside>
+    <div className="bg-background sticky top-20 z-10 h-[calc(100vh-7rem)] max-md:container">
+      <ScrollArea className="h-[calc(100vh-7rem)]">
+        <aside>
+          <div className="max-md:pt-8 max-md:pb-2">
             {SIDEBAR_NAVIGATION.map((page) => (
               <div key={page.title}>
                 {/* First child should not have a margin top of 4 */}
@@ -80,80 +78,9 @@ export function DocsSidebar() {
                 </ul>
               </div>
             ))}
-          </aside>
-        </ScrollArea>
-      </div>
-
-      <div
-        className={cn(
-          "fixed top-16 left-0 z-10 hidden w-full max-md:block",
-          !isOpen
-            ? "bg-background/80 border-b backdrop-blur-sm"
-            : "bg-background",
-        )}
-      >
-        <button
-          onClick={toggleMobileMenu}
-          className="container flex h-10 w-full cursor-pointer items-center"
-        >
-          {isOpen ? (
-            <ChevronDownIcon className="size-5" />
-          ) : (
-            <ChevronRightIcon className="size-5" />
-          )}
-          <span className="ml-1.5">Menu</span>
-        </button>
-      </div>
-
-      {isOpen && (
-        <ScrollArea className="h-[calc(100vh-6.5rem)] pt-8 pb-2">
-          <aside>
-            {SIDEBAR_NAVIGATION.map((page) => (
-              <div key={page.title}>
-                {/* First child should not have a margin top of 4 */}
-                <H3 className="text-xl">{page.title}</H3>
-                <ul className="mb-4 ml-4">
-                  {page.items.map((item) => {
-                    const isActive = pathname.includes(item.slug)
-                    return (
-                      <li key={item.slug}>
-                        <Link href={`/docs/${item.slug}`} className="block">
-                          <div className="relative">
-                            {isActive && (
-                              <motion.div
-                                layoutId="sidebarActiveItem"
-                                className="bg-primary/10 border-primary absolute inset-0 border-l-2"
-                                initial={false}
-                                transition={{
-                                  type: "spring",
-                                  stiffness: 500,
-                                  damping: 30,
-                                }}
-                              />
-                            )}
-                            <span
-                              className={cn(
-                                "relative z-10 block px-4 py-2",
-                                "hover:text-primary hover:bg-primary/5",
-                                "border-primary/20 hover:border-primary/50 border-l-2",
-                                isActive
-                                  ? "text-primary"
-                                  : "text-muted-foreground",
-                              )}
-                            >
-                              {item.title}
-                            </span>
-                          </div>
-                        </Link>
-                      </li>
-                    )
-                  })}
-                </ul>
-              </div>
-            ))}
-          </aside>
-        </ScrollArea>
-      )}
-    </>
+          </div>
+        </aside>
+      </ScrollArea>
+    </div>
   )
 }

--- a/docs/src/components/docs/sidebar.tsx
+++ b/docs/src/components/docs/sidebar.tsx
@@ -12,9 +12,10 @@ import { H3 } from "@/mdx-components"
 
 interface DocsSidebarProps {
   isOpen?: boolean
+  setIsOpen?: () => void
 }
 
-export function DocsSidebar({ isOpen }: DocsSidebarProps) {
+export function DocsSidebar({ isOpen, setIsOpen }: DocsSidebarProps) {
   const pathname = usePathname()
 
   useEffect(() => {
@@ -44,7 +45,13 @@ export function DocsSidebar({ isOpen }: DocsSidebarProps) {
                     const isActive = pathname.includes(item.slug)
                     return (
                       <li key={item.slug}>
-                        <Link href={`/docs/${item.slug}`} className="block">
+                        <Link
+                          href={`/docs/${item.slug}`}
+                          onClick={() => {
+                            setTimeout(() => setIsOpen && setIsOpen(), 100)
+                          }}
+                          className="block"
+                        >
                           <div className="relative">
                             {isActive && (
                               <motion.div

--- a/docs/src/components/docs/toc.tsx
+++ b/docs/src/components/docs/toc.tsx
@@ -132,7 +132,9 @@ export function DocsTOC() {
                         block: "start",
                       })
                       history.pushState(null, "", `#${heading.id}`)
-                      setActiveId(heading.id) // Immediately update active state
+                      setTimeout(() => {
+                        setActiveId(heading.id)
+                      }, 300)
                     }
                   }}
                 >

--- a/docs/src/components/docs/toc.tsx
+++ b/docs/src/components/docs/toc.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { MessageSquareIcon, PenIcon } from "lucide-react"
+import { ArrowUpCircleIcon, MessageSquareIcon, PenIcon } from "lucide-react"
 import { motion } from "motion/react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -32,6 +32,7 @@ export function DocsTOC() {
 
   const [headings, setHeadings] = useState<Heading[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
+  const [showBackToTop, setShowBackToTop] = useState(false)
 
   useEffect(() => {
     const mdxContent = document.getElementById("mdx")
@@ -94,6 +95,16 @@ export function DocsTOC() {
     window.addEventListener("scroll", handleScroll)
     return () => window.removeEventListener("scroll", handleScroll)
   }, [headings, pathname])
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const halfwayPoint = window.innerHeight / 2
+      setShowBackToTop(window.scrollY > halfwayPoint)
+    }
+
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
 
   return (
     <div className="sticky top-20 hidden lg:block">
@@ -180,6 +191,24 @@ export function DocsTOC() {
             <MessageSquareIcon className="size-3.5 fill-current" />
             Give feedback
           </Link>
+        </li>
+        <li>
+          <button
+            onClick={() =>
+              window.scrollTo({
+                top: 0,
+                behavior: "smooth",
+              })
+            }
+            className={cn(
+              "text-muted-foreground hover:text-primary flex items-center gap-1.5 text-sm opacity-0 transition-all hover:underline",
+              showBackToTop && "opacity-100",
+            )}
+            aria-label="Back to Top"
+          >
+            <ArrowUpCircleIcon className="size-3.5" />
+            Back to top
+          </button>
         </li>
       </ul>
     </div>

--- a/docs/src/components/docs/toc.tsx
+++ b/docs/src/components/docs/toc.tsx
@@ -70,8 +70,8 @@ export function DocsTOC() {
         }
       },
       {
-        rootMargin: "-20% 0px -60% 0px", // More forgiving, triggers earlier
-        threshold: 0.1, // Fires when at least 10% of the heading is visible
+        rootMargin: "0px 0px -30% 0px",
+        threshold: 1,
       },
     )
 
@@ -87,7 +87,7 @@ export function DocsTOC() {
   useEffect(() => {
     const handleScroll = () => {
       if (window.scrollY === 0 && headings.length > 0) {
-        setActiveId(headings[0].id) // Keep first heading active
+        setActiveId(headings[0].id)
         history.replaceState(null, "", `#${headings[0].id}`)
       }
     }
@@ -116,10 +116,7 @@ export function DocsTOC() {
             const isActive = activeId === heading.id
 
             return (
-              <li
-                key={heading.id}
-                style={{ paddingLeft: `${heading.level * 4}px` }}
-              >
+              <li key={heading.id}>
                 <Link
                   href={`#${heading.id}`}
                   className="block"
@@ -160,6 +157,7 @@ export function DocsTOC() {
                           ? "text-primary font-medium"
                           : "text-muted-foreground",
                       )}
+                      style={{ paddingLeft: `${heading.level * 10}px` }}
                     >
                       {heading.text}
                     </span>

--- a/docs/src/components/docs/toc.tsx
+++ b/docs/src/components/docs/toc.tsx
@@ -6,7 +6,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
 
-import { GITHUB_CREATE_TNT_APP_REPO } from "@/constants"
+import { GITHUB_CREATE_TNT_APP_REPO, SIDEBAR_NAVIGATION } from "@/constants"
 import { cn } from "@/lib/utils"
 import { H3 } from "@/mdx-components"
 
@@ -18,8 +18,17 @@ interface Heading {
 
 export function DocsTOC() {
   const pathname = usePathname()
-  const pathWithoutPrefix = pathname.replace("/docs/", "")
-  const repoPath = `${GITHUB_CREATE_TNT_APP_REPO}/tree/main/docs/src/content/${pathWithoutPrefix}.mdx`
+
+  // Extract the visible path and find the matched slug
+  const visiblePath = pathname.replace(/^\/docs\/\(([^)]+)\)/, "/docs")
+  const matchedSlug = SIDEBAR_NAVIGATION.find((section) =>
+    section.items.some((item) => visiblePath.includes(item.slug)),
+  )?.slug
+
+  // Construct the repo path
+  const repoPath = `${GITHUB_CREATE_TNT_APP_REPO}/blob/main/docs/src/app/docs/${
+    matchedSlug ? `(${matchedSlug})` : ""
+  }${visiblePath.replace("/docs", "")}/page.mdx`
 
   const [headings, setHeadings] = useState<Heading[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)

--- a/docs/src/components/footer.tsx
+++ b/docs/src/components/footer.tsx
@@ -4,7 +4,10 @@ import Link from "next/link"
 import { Logo } from "@/components/logo"
 import { Anchor } from "@/components/mdx/anchor"
 import { Button } from "@/components/ui/button"
-import { GITHUB_CREATE_TNT_APP_REPO } from "@/constants"
+import {
+  GITHUB_CREATE_TNT_APP_REPO,
+  RELATIVE_INITIAL_DOCS_PATH,
+} from "@/constants"
 
 export function Footer() {
   return (
@@ -30,7 +33,7 @@ export function Footer() {
         <div className="text-muted-foreground flex flex-col items-start gap-4 text-sm md:flex-row md:items-center md:justify-between md:gap-6">
           <div className="flex flex-col gap-2 md:flex-row md:gap-4">
             <Anchor
-              href="/docs/create-tnt-stack/introduction"
+              href={RELATIVE_INITIAL_DOCS_PATH}
               className="text-muted-foreground hover:underline"
             >
               Documentation

--- a/docs/src/components/header.tsx
+++ b/docs/src/components/header.tsx
@@ -1,11 +1,18 @@
 "use client"
 
-import { MenuIcon, StarIcon, XIcon } from "lucide-react"
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  MenuIcon,
+  StarIcon,
+  XIcon,
+} from "lucide-react"
 import { motion } from "motion/react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
 
+import { DocsSidebar } from "@/components/docs/sidebar"
 import { Logo } from "@/components/logo"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { Button } from "@/components/ui/button"
@@ -24,9 +31,16 @@ export function Header() {
   const pathname = usePathname()
   const navRefs = useRef<(HTMLAnchorElement | null)[]>([])
 
+  const isDocs = pathname.startsWith("/docs")
+
+  const [isOpen, setIsOpen] = useState<boolean>(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
+
+  const toggleMobileMenu = () => {
+    setIsOpen(!isOpen)
+  }
 
   useEffect(() => {
     const activeIndex = NAVIGATION.findIndex(
@@ -42,147 +56,183 @@ export function Header() {
   }, [pathname])
 
   return (
-    <motion.header
-      initial={{ opacity: 0, y: -20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5 }}
-      className="bg-background/80 sticky top-0 z-50 w-full border-b backdrop-blur-sm"
-    >
-      <div className="container flex h-16 items-center justify-between">
-        <div className="flex items-center gap-6">
-          <Link href="/">
-            <Logo />
-          </Link>
+    <>
+      <motion.header
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className={cn(
+          "sticky top-0 z-50 w-full border-b backdrop-blur-sm",
+          isOpen ? "bg-background" : "bg-background/80",
+        )}
+      >
+        <div className="container flex h-16 items-center justify-between">
+          <div className="flex items-center gap-6">
+            <Link href="/">
+              <Logo />
+            </Link>
 
-          <nav className="relative hidden lg:block">
-            {/* Hover Highlight */}
-            <motion.div
-              layout
-              initial={false}
-              animate={
-                hoveredIndex !== null && navRefs.current[hoveredIndex]
-                  ? {
-                      opacity: 1,
-                      left: navRefs.current[hoveredIndex]!.offsetLeft,
-                      width: navRefs.current[hoveredIndex]!.offsetWidth,
-                    }
-                  : { opacity: 0 }
-              }
-              className="bg-muted/50 absolute flex h-[30px] items-center rounded-[6px]"
-            />
+            <nav className="relative hidden lg:block">
+              {/* Hover Highlight */}
+              <motion.div
+                layout
+                initial={false}
+                animate={
+                  hoveredIndex !== null && navRefs.current[hoveredIndex]
+                    ? {
+                        opacity: 1,
+                        left: navRefs.current[hoveredIndex]!.offsetLeft,
+                        width: navRefs.current[hoveredIndex]!.offsetWidth,
+                      }
+                    : { opacity: 0 }
+                }
+                className="bg-muted/50 absolute flex h-[30px] items-center rounded-[6px]"
+              />
 
-            {/* Active Indicator */}
-            <motion.div
-              layout
-              initial={false}
-              animate={{
-                left: indicatorStyle.left,
-                width: indicatorStyle.width,
-              }}
-              className="bg-primary absolute bottom-[-18px] h-px rounded-full"
-            />
+              {/* Active Indicator */}
+              <motion.div
+                layout
+                initial={false}
+                animate={{
+                  left: indicatorStyle.left,
+                  width: indicatorStyle.width,
+                }}
+                className="bg-primary absolute bottom-[-18px] h-px rounded-full"
+              />
 
-            <div className="relative flex items-center space-x-[6px]">
-              {NAVIGATION.map(({ href, label }, index) => (
+              <div className="relative flex items-center space-x-[6px]">
+                {NAVIGATION.map(({ href, label }, index) => (
+                  <Link
+                    key={index}
+                    href={href}
+                    ref={(el) => {
+                      navRefs.current[index] = el
+                    }}
+                    onMouseEnter={() => setHoveredIndex(index)}
+                    onMouseLeave={() => setHoveredIndex(null)}
+                    className={cn(
+                      "h-[30px] cursor-pointer px-3 py-2 transition-colors duration-300",
+                      (pathname.startsWith("/docs") &&
+                        href === RELATIVE_INITIAL_DOCS_PATH) ||
+                        href === pathname
+                        ? "text-primary"
+                        : "text-foreground",
+                    )}
+                  >
+                    <div className="flex h-full items-center justify-center leading-5 whitespace-nowrap">
+                      {label}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </nav>
+          </div>
+
+          <motion.div
+            initial={{ opacity: 0, x: 10 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: 0.2, duration: 0.5 }}
+            className="hidden items-center gap-2 lg:flex"
+          >
+            <Button variant="outline" asChild>
+              <Link href={GITHUB_CREATE_TNT_APP_REPO} target="_blank">
+                <StarIcon className="size-4 fill-yellow-500 stroke-yellow-500 dark:fill-yellow-400 dark:stroke-yellow-400" />
+                Star on GitHub
+              </Link>
+            </Button>
+            <ThemeToggle />
+          </motion.div>
+
+          <div className="flex items-center gap-2 lg:hidden">
+            <Button
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              size="icon"
+              variant="outline"
+              aria-label="Toggle menu"
+            >
+              {mobileMenuOpen ? (
+                <XIcon className="size-5" />
+              ) : (
+                <MenuIcon className="size-5" />
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {/* Mobile menu */}
+        {mobileMenuOpen && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="lg:hidden"
+          >
+            <div className="z-10 container flex flex-col gap-4 py-4">
+              {NAVIGATION.map(({ href, label }) => (
                 <Link
-                  key={index}
+                  key={label}
                   href={href}
-                  ref={(el) => {
-                    navRefs.current[index] = el
+                  onClick={() => {
+                    /**
+                     * Hack to close the menu after navigating
+                     */
+                    setTimeout(() => setMobileMenuOpen(false), 100)
                   }}
-                  onMouseEnter={() => setHoveredIndex(index)}
-                  onMouseLeave={() => setHoveredIndex(null)}
                   className={cn(
-                    "h-[30px] cursor-pointer px-3 py-2 transition-colors duration-300",
+                    "hover:text-primary text-foreground rounded-md border p-4 text-sm font-medium transition-colors",
                     (pathname.startsWith("/docs") &&
                       href === RELATIVE_INITIAL_DOCS_PATH) ||
                       href === pathname
-                      ? "text-primary"
-                      : "text-foreground",
+                      ? "bg-primary/10 border-primary"
+                      : "border-border/ bg-input/10",
                   )}
                 >
-                  <div className="flex h-full items-center justify-center leading-5 whitespace-nowrap">
-                    {label}
-                  </div>
+                  {label}
                 </Link>
               ))}
+
+              <div className="bg-border h-px w-full" />
+
+              <div className="flex items-center gap-2">
+                <Button variant="outline" className="flex-1" asChild>
+                  <Link href={GITHUB_CREATE_TNT_APP_REPO} target="_blank">
+                    <StarIcon className="size-4 fill-yellow-500 stroke-yellow-500 dark:fill-yellow-400 dark:stroke-yellow-400" />
+                    Star on GitHub
+                  </Link>
+                </Button>
+                <ThemeToggle />
+              </div>
             </div>
-          </nav>
-        </div>
+          </motion.div>
+        )}
+      </motion.header>
 
-        <motion.div
-          initial={{ opacity: 0, x: 10 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ delay: 0.2, duration: 0.5 }}
-          className="hidden items-center gap-2 lg:flex"
-        >
-          <Button variant="outline" asChild>
-            <Link href={GITHUB_CREATE_TNT_APP_REPO} target="_blank">
-              <StarIcon className="size-4 fill-yellow-500 stroke-yellow-500 dark:fill-yellow-400 dark:stroke-yellow-400" />
-              Star on GitHub
-            </Link>
-          </Button>
-          <ThemeToggle />
-        </motion.div>
-
-        <div className="flex items-center gap-2 lg:hidden">
-          <Button
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            size="icon"
-            variant="outline"
-            aria-label="Toggle menu"
-          >
-            {mobileMenuOpen ? (
-              <XIcon className="size-5" />
-            ) : (
-              <MenuIcon className="size-5" />
+      {isDocs && (
+        <>
+          <div
+            className={cn(
+              "sticky top-16 left-0 z-20 hidden max-md:block",
+              !isOpen
+                ? "bg-background/80 border-b backdrop-blur-sm"
+                : "bg-background",
             )}
-          </Button>
-        </div>
-      </div>
-
-      {/* Mobile menu */}
-      {mobileMenuOpen && (
-        <motion.div
-          //   className="lg:hidden"
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: "auto" }}
-          exit={{ opacity: 0, height: 0 }}
-          transition={{ duration: 0.2 }}
-        >
-          <div className="container flex flex-col gap-4 py-4">
-            {NAVIGATION.map(({ href, label }) => (
-              <Link
-                key={label}
-                href={href}
-                onClick={() => setMobileMenuOpen(false)}
-                className={cn(
-                  "hover:text-primary text-foreground rounded-md border p-4 text-sm font-medium transition-colors",
-                  (pathname.startsWith("/docs") &&
-                    href === RELATIVE_INITIAL_DOCS_PATH) ||
-                    href === pathname
-                    ? "bg-primary/10 border-primary"
-                    : "border-border/ bg-input/10",
-                )}
-              >
-                {label}
-              </Link>
-            ))}
-
-            <div className="bg-border h-px w-full" />
-
-            <div className="flex items-center gap-2">
-              <Button variant="outline" className="flex-1" asChild>
-                <Link href={GITHUB_CREATE_TNT_APP_REPO} target="_blank">
-                  <StarIcon className="size-4 fill-yellow-500 stroke-yellow-500 dark:fill-yellow-400 dark:stroke-yellow-400" />
-                  Star on GitHub
-                </Link>
-              </Button>
-              <ThemeToggle />
-            </div>
+          >
+            <button
+              onClick={toggleMobileMenu}
+              className="container flex h-10 w-full cursor-pointer items-center"
+            >
+              {isOpen ? (
+                <ChevronDownIcon className="size-5" />
+              ) : (
+                <ChevronRightIcon className="size-5" />
+              )}
+              <span className="ml-1.5">Menu</span>
+            </button>
           </div>
-        </motion.div>
+          {isOpen && <DocsSidebar isOpen={isOpen} />}
+        </>
       )}
-    </motion.header>
+    </>
   )
 }

--- a/docs/src/components/header.tsx
+++ b/docs/src/components/header.tsx
@@ -9,12 +9,15 @@ import { useEffect, useRef, useState } from "react"
 import { Logo } from "@/components/logo"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { Button } from "@/components/ui/button"
-import { GITHUB_CREATE_TNT_APP_REPO } from "@/constants"
+import {
+  GITHUB_CREATE_TNT_APP_REPO,
+  RELATIVE_INITIAL_DOCS_PATH,
+} from "@/constants"
 import { cn } from "@/lib/utils"
 
 const NAVIGATION = [
   { href: "/", label: "Home" },
-  { href: "/docs/introduction", label: "Docs" },
+  { href: RELATIVE_INITIAL_DOCS_PATH, label: "Docs" },
 ]
 
 export function Header() {
@@ -29,7 +32,7 @@ export function Header() {
     const activeIndex = NAVIGATION.findIndex(
       (item) =>
         item.href ===
-        (pathname.startsWith("/docs") ? "/docs/introduction" : pathname),
+        (pathname.startsWith("/docs") ? RELATIVE_INITIAL_DOCS_PATH : pathname),
     )
     if (activeIndex !== -1 && navRefs.current[activeIndex]) {
       const activeElement = navRefs.current[activeIndex]
@@ -92,7 +95,7 @@ export function Header() {
                   className={cn(
                     "h-[30px] cursor-pointer px-3 py-2 transition-colors duration-300",
                     (pathname.startsWith("/docs") &&
-                      href === "/docs/introduction") ||
+                      href === RELATIVE_INITIAL_DOCS_PATH) ||
                       href === pathname
                       ? "text-primary"
                       : "text-foreground",
@@ -156,7 +159,7 @@ export function Header() {
                 className={cn(
                   "hover:text-primary text-foreground rounded-md border p-4 text-sm font-medium transition-colors",
                   (pathname.startsWith("/docs") &&
-                    href === "/docs/introduction") ||
+                    href === RELATIVE_INITIAL_DOCS_PATH) ||
                     href === pathname
                     ? "bg-primary/10 border-primary"
                     : "border-border/ bg-input/10",

--- a/docs/src/components/header.tsx
+++ b/docs/src/components/header.tsx
@@ -230,7 +230,9 @@ export function Header() {
               <span className="ml-1.5">Menu</span>
             </button>
           </div>
-          {isOpen && <DocsSidebar isOpen={isOpen} />}
+          {isOpen && (
+            <DocsSidebar isOpen={isOpen} setIsOpen={toggleMobileMenu} />
+          )}
         </>
       )}
     </>

--- a/docs/src/components/home/cta.tsx
+++ b/docs/src/components/home/cta.tsx
@@ -5,7 +5,10 @@ import { motion } from "motion/react"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
-import { GITHUB_CREATE_TNT_APP_REPO } from "@/constants"
+import {
+  GITHUB_CREATE_TNT_APP_REPO,
+  RELATIVE_INITIAL_DOCS_PATH,
+} from "@/constants"
 
 export function CTA() {
   return (
@@ -29,7 +32,7 @@ export function CTA() {
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Button size="lg" className="group" asChild>
-              <Link href="/docs/create-tnt-stack/introduction">
+              <Link href={RELATIVE_INITIAL_DOCS_PATH}>
                 <span>Read the Docs</span>
                 <ArrowRightIcon className="ml-2 size-4 transition-transform group-hover:translate-x-1" />
               </Link>

--- a/docs/src/components/home/hero.tsx
+++ b/docs/src/components/home/hero.tsx
@@ -13,7 +13,10 @@ import { CodeBlock } from "@/components/code-block"
 import { TerminalDemo } from "@/components/terminal-demo"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { GITHUB_CREATE_TNT_APP_REPO } from "@/constants"
+import {
+  GITHUB_CREATE_TNT_APP_REPO,
+  RELATIVE_INITIAL_DOCS_PATH,
+} from "@/constants"
 
 export function Hero() {
   return (
@@ -69,7 +72,7 @@ export function Hero() {
               className="group min-h-[3.5rem] flex-1"
               asChild
             >
-              <Link href="/docs/introduction">
+              <Link href={RELATIVE_INITIAL_DOCS_PATH}>
                 <FileCode2Icon className="mr-2 size-4" />
                 <span>Get Started</span>
                 <ArrowRightIcon className="ml-2 size-4 transition-transform group-hover:translate-x-1" />

--- a/docs/src/components/home/hero.tsx
+++ b/docs/src/components/home/hero.tsx
@@ -66,7 +66,7 @@ export function Hero() {
             <Button
               size="lg"
               variant="outline"
-              className="group h-[3.25rem] flex-1"
+              className="group min-h-[3.5rem] flex-1"
               asChild
             >
               <Link href="/docs/introduction">
@@ -79,7 +79,7 @@ export function Hero() {
             <Button
               size="lg"
               variant="outline"
-              className="group h-[3.25rem] flex-1"
+              className="group min-h-[3.5rem] flex-1"
               asChild
             >
               <Link href={GITHUB_CREATE_TNT_APP_REPO} target="_blank">

--- a/docs/src/components/home/usage.tsx
+++ b/docs/src/components/home/usage.tsx
@@ -121,7 +121,7 @@ export function Usage() {
 
               <div className="pt-4">
                 <Button className="group" asChild>
-                  <Link href="/docs/create-tnt-stack/getting-started#experimental-ci-flags">
+                  <Link href="/docs/getting-started#experimental-ci-flags">
                     View Full Documentation
                     <ArrowRightIcon className="size-4 transition-transform group-hover:translate-x-1" />
                   </Link>

--- a/docs/src/components/mdx/figcaption.tsx
+++ b/docs/src/components/mdx/figcaption.tsx
@@ -4,7 +4,7 @@ interface FigcaptionProps {
 
 export function Figcaption({ children }: FigcaptionProps) {
   return (
-    <figcaption className="bg-muted/80 border-muted -mb-6 min-w-sm rounded-t-lg border px-5 py-2">
+    <figcaption className="bg-muted/80 border-input/80 -mb-6 min-w-sm rounded-t-lg border px-5 py-2">
       {children}
     </figcaption>
   )

--- a/docs/src/components/mdx/figcaption.tsx
+++ b/docs/src/components/mdx/figcaption.tsx
@@ -4,7 +4,7 @@ interface FigcaptionProps {
 
 export function Figcaption({ children }: FigcaptionProps) {
   return (
-    <figcaption className="bg-muted/80 border-input/80 -mb-6 min-w-sm rounded-t-lg border px-5 py-2">
+    <figcaption className="bg-muted/80 border-input/80 -mb-6 w-auto rounded-t-lg border px-5 py-2 md:min-w-sm">
       {children}
     </figcaption>
   )

--- a/docs/src/components/mdx/pre.tsx
+++ b/docs/src/components/mdx/pre.tsx
@@ -43,7 +43,7 @@ export function Pre({
     <div className="relative">
       <pre
         className={cn(
-          "dark:bg-input/30 bg-background group border-input my-6 min-w-sm overflow-x-scroll rounded-lg border py-4 shadow-xs",
+          "dark:bg-input/30 bg-background group border-input my-6 w-auto overflow-x-scroll rounded-lg border py-4 shadow-xs md:min-w-sm",
           className,
         )}
         {...props}

--- a/docs/src/components/mdx/pre.tsx
+++ b/docs/src/components/mdx/pre.tsx
@@ -84,6 +84,7 @@ export function Code({
   "data-language": language,
   ...props
 }: PreProps) {
+  // Inline code block styling
   if (!language) {
     return (
       <code

--- a/docs/src/constants/index.ts
+++ b/docs/src/constants/index.ts
@@ -15,6 +15,7 @@ export const SIDEBAR_NAVIGATION = [
   // Create TNT Stack
   {
     title: "Create TNT Stack",
+    slug: "create-tnt-stack",
     items: [
       { slug: "introduction", title: "Introduction" },
       { slug: "getting-started", title: "Getting Started" },
@@ -24,6 +25,7 @@ export const SIDEBAR_NAVIGATION = [
   // Usage
   {
     title: "Usage",
+    slug: "usage",
     items: [
       { slug: "first-steps", title: "First Steps" },
       { slug: "nextjs", title: "Next.js" },
@@ -33,6 +35,7 @@ export const SIDEBAR_NAVIGATION = [
   // Deploymeny
   //   {
   //     title: "Deployment",
+  //     slug: "deployment",
   //     items: [
   //       { slug: "vercel", title: "Vercel" },
   //       { slug: "netlify", title: "Netlify" },
@@ -41,9 +44,10 @@ export const SIDEBAR_NAVIGATION = [
   // Roadmap
   {
     title: "Roadmap",
+    slug: "roadmap",
     items: [{ slug: "v1", title: "Version 1" }],
   },
-]
+] as const
 
 export type FeatureType = {
   title: string

--- a/docs/src/constants/index.ts
+++ b/docs/src/constants/index.ts
@@ -8,6 +8,8 @@ import {
   ZapIcon,
 } from "lucide-react"
 
+export const RELATIVE_INITIAL_DOCS_PATH = "/docs/introduction"
+
 export const GITHUB_CREATE_TNT_APP_REPO =
   "https://github.com/SlickYeet/create-tnt-stack"
 


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md)
      (updated 2025-03-17).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- adjust primary color and button height for improved UI consistency
- replace title div with Figcaption component in CodeBlock for improved semantics
- enhance DocsTOC component to construct repo path using SIDEBAR_NAVIGATION slugs
- update navigation to use RELATIVE_INITIAL_DOCS_PATH for improved path management
- update documentation links
- refactor DocsSidebar for improved layout and responsiveness
- add setIsOpen prop to DocsSidebar to close menu after navigation
- add "Back to Top" button in TOC
- enhance README with detailed site structure and features, update globals.css for table styling, and add inline code block comment in pre.tsx
- add delay to setActiveId in DocsTOC for smoother navigation experience
- adjust intersection observer settings and improve heading indentation in TOC

---

💯
