### PR TITLE
fix(docs): adjust search results to show top 4 docs when query is empty

### DIFF
--- a/docs/src/components/docs/search.tsx
+++ b/docs/src/components/docs/search.tsx
@@ -60,13 +60,16 @@ export function Search({ docs }: { docs: MdxDocument[] }) {
   }, [pathname])
 
   const fuse = new Fuse(docs, {
+    threshold: 0.3,
     keys: ["title", "description"],
   })
 
   const results: MdxDocument[] =
     debouncedQuery.length > 1
       ? fuse.search(debouncedQuery).map((result) => result.item)
-      : []
+      : query === ""
+        ? docs.slice(0, 4)
+        : []
 
   const handleSearch = (query: string) => {
     setQuery(query)


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

Search dialog now shows first 4 docs when query is empty 

---

💯
