### PR TITLE
fix(ci): update label from '🚀 autorelease' to '🚀 betarelease' in workflow files

### DIFF
--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -60,5 +60,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ env.WORKFLOW_RUN_PR }},
-              name: '🚀 autorelease',
+              name: '🚀 betarelease',
             });

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ jobs:
   prerelease:
     if: |
       github.repository_owner == 'SlickYeet' &&
-      contains(github.event.pull_request.labels.*.name, '🚀 autorelease')
+      contains(github.event.pull_request.labels.*.name, '🚀 betarelease')
     name: Build & Publish a beta release to NPM
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- update label from '🚀 autorelease' to '🚀 betarelease' in workflow files

---

💯
