### PR TITLE
fix(ci): correctly format NPM authentication command and update labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@
 "📌 area: tnt-app":
   - any: ["cli/template/**/*"]
 
-"📚 docs":
+"📚 site":
   - any: ["docs/**/*"]
   - any: ["**/*.md", "**/*.mdx"]
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,9 +26,8 @@ jobs:
         run: node .github/version-script-beta.js
 
       - name: Authenticate to NPM
-        run:
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ACCESS_TOKEN
-          }}" > cli/.npmrc
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ACCESS_TOKEN }}" > cli/.npmrc
 
       - name: Publish Beta to NPM
         run: bun pub:beta

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.github/workflows


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- correctly format NPM authentication command
- add `.prettierignore`
- rename label from '📚 docs' to '📚 site' 

---

💯
