### PR TITLE
fix(ci): await the removeLabel call in prerelease-comment.yml

### DIFF
--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -62,9 +62,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.issues.removeLabel({
+            await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ env.WORKFLOW_RUN_PR }},
-              name: '🚀 betarelease',
+              name: '🚀 betarelease'
             });


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- await the removeLabel
- remove last comma

---

💯
