### PR TITLE
fix(ci): ensure comment is posted only for PRs with beta release label

### DIFF
--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -10,6 +10,7 @@ jobs:
   comment:
     if: |
       github.repository_owner == 'SlickYeet' &&
+      contains(github.event.pull_request.labels.*.name, '🚀 betarelease')
       ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Write comment to the PR


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-tnt-stack/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- ensure comment is posted only for PRs with beta release label

---

💯
